### PR TITLE
Added ProjectMru command

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,17 @@
 This is a Vim plugin that tracks your most recently and frequently used files
 while using the [fzf.vim](https://github.com/junegunn/fzf.vim) plugin.
 
-This plugin provides the `FilesMru` command, which is basically a pass-through
-to the `Files` command.  So, all you really need to do is use `FilesMru`
-instead of `Files`.
+This plugin provides the `FilesMru` and `ProjectMru` commands, which are
+basically a pass-throughs to the `Files` command.  So, all you really need to
+do is use `FilesMru` instead of `Files`.
 
-When using `FilesMru`, FZF will display files like usual, except your most
-recently used files (matching the working directory) will appear before all
-other files.
+When using `FilesMru` or `ProjectMru`, FZF will display files like usual,
+except your most recently used files (matching the working directory) will
+appear before all other files.
+
+`ProjectMru` does the same thing as `FilesMru` except that it uses
+`git ls-tree` to display files after MRU files (and before other found files),
+and ignores repository submodule directories.
 
 MRU files are tracked in `$XDG_CACHE_HOME/fzf_filemru`.  A timestamp (rounded
 to 2 minute intervals) and selection count is used to determine recency and
@@ -19,7 +23,7 @@ frequency.
 ## Example Usage
 
 ```vim
-nnoremap <c-p> :FilesMru --tiebreak=index<cr>
+nnoremap <c-p> :FilesMru --tiebreak=end<cr>
 ```
 
 
@@ -32,18 +36,26 @@ nnoremap <c-p> :FilesMru --tiebreak=index<cr>
 
 # Command Usage
 
-`FilesMru` ignores the original `directory` argument and instead takes flags
+The commands ignore the original `directory` argument and instead takes flags
 that are passed FZF.  Run `fzf --help` to see what flags you can pass.  A
 decent flag to use is `--tiebreak=index` which uses the initial order of the
-listed file as a secondary sort.
+listed file as a secondary sort.  `--tiebreak=end` will do a better job of
+sorting filename matches first.
 
 
 ## Options
 
-Option | Description
------- | -----------
-`g:fzf_filemru_bufwrite` | Update the MRU on `BufWritePost`.  This can be useful if you want your most saved files to appear near the top of the results.  Default: `0`
-~~g:fzf_filemru_nosort~~ | Removed.  Use `FilesMru --no-sort` instead.
+- `g:fzf_filemru_bufwrite` - Update the MRU on `BufWritePost`.  This can be
+  useful if you want your most saved files to appear near the top of the
+  results.  Default: `0`
+- `g:fzf_filemru_git_ls` - Use `git ls-tree` to display repo files before other
+  files that are found with the the finder command.  Always enabled for
+  `ProjectMru`.  Default: `0`
+- `g:fzf_filemru_ignore_submodule` - Ignore git submodule directories.  Always
+  enabled for `ProjectMru`.  Default: `0`
+
+**Note:** Even if git submodule files are ignored, they can still appear in the
+MRU.
 
 
 ## Command Line
@@ -56,8 +68,11 @@ its own.
 
 ### Command Line Switches
 
-Switch | Description
------- | -----------
---exclude | Exclude a file from MRU output.  Must be the first switch and relative to the current directory.
---files | Just find files with MRU files displayed first and exit.
---update | Updates the MRU with the files specified after this switch.  The files must be relative to the current directory.
+- `--exclude` - Exclude a file from MRU output.  Must be relative to the
+  current directory.
+- `--files` | Just find files with MRU files displayed first and exit.
+- `--update` | Updates the MRU with the files specified after this switch.  The
+  files must be relative to the current directory.
+- `--git` | Use `git ls-tree` to display repo files after MRU files, but before
+  other found files.
+- `--ignore-submodules` | Ignore git submodule directories.

--- a/plugin/fzf-filemru.vim
+++ b/plugin/fzf-filemru.vim
@@ -5,7 +5,7 @@ let s:filemru_bin = resolve(printf('%s/../bin/filemru.sh', expand('<sfile>:p:h')
 let s:ignore_patterns = '\.git/\|\_^/tmp/'
 
 
-function! s:update_mru(files)
+function! s:update_mru(files) abort
   let selections = filter(copy(a:files), '!empty(v:val) && v:val !~# s:ignore_patterns')
   if empty(selections)
     return
@@ -22,7 +22,7 @@ endfunction
 
 
 " Update MRU and pass-through to s:common_sink
-function! s:filemru_sink(lines)
+function! s:filemru_sink(lines) abort
   call s:update_mru(a:lines)
   if exists('s:common_sink')
     call s:common_sink(a:lines)
@@ -30,30 +30,52 @@ function! s:filemru_sink(lines)
 endfunction
 
 
-function! s:fzf_filemru(...)
+function! s:invoke(git_ls, ignore_submodule, options) abort
   if !exists('s:common_sink')
     " Grab a reference to fzf.vim's s:common_sink
-    let default_opts = fzf#vim#wrap({})
-    let s:common_sink = get(default_opts, 'sink*')
+    let s:common_sink = get(fzf#vim#wrap({}), 'sink*')
   endif
 
   let fzf_source = s:filemru_bin
-  let buffer_file = expand('%')
-  if empty(&l:buftype) && !empty(&l:filetype) && !empty(buffer_file)
-    let fzf_source .= ' --exclude '.buffer_file
+  let exclude = expand('%')
+  if empty(&l:buftype) && !empty(&l:filetype) && !empty(exclude)
+    let fzf_source .= ' --exclude '.exclude
   endif
+
+  if a:git_ls
+    let fzf_source .= ' --git'
+  endif
+
+  if a:ignore_submodule
+    let fzf_source .= ' --ignore-submodules'
+  endif
+
   let fzf_source .= ' --files'
   let options = {
         \   'source': fzf_source,
         \   'sink*': function('s:filemru_sink'),
-        \   'options': join(a:000, ' '),
+        \   'options': a:options,
         \ }
   let extra = extend(copy(get(g:, 'fzf_layout', g:fzf#vim#default_layout)), options)
   call fzf#vim#files('', extra)
 endfunction
 
 
+function! s:fzf_filemru(...) abort
+  call s:invoke(
+        \ get(g:, 'fzf_filemru_git_ls', 0),
+        \ get(g:, 'fzf_filemru_ignore_submodule', 0),
+        \ join(a:000, ' '))
+endfunction
+
+
+function! s:fzf_projectmru(...) abort
+  call s:invoke(1, 1, join(a:000, ' '))
+endfunction
+
+
 command! -nargs=* FilesMru call s:fzf_filemru(<q-args>)
+command! -nargs=* ProjectMru call s:fzf_projectmru(<q-args>)
 
 
 if get(g:, 'fzf_filemru_bufwrite', 0)


### PR DESCRIPTION
@af @gabrielflorit @cfebs @simonsmith @mattsawyer77

Hi all!  Since you seem to be the only ones using this plugin, I figured I'd notify you of a significant addition because I felt it'd be a shame if you updated it without noticing.

I added a few options for dealing with git repositories.  One to prioritize git files, and another to filter out git submodules.  You may find this command to be the most useful for as a ctrlp replacement:

``` vim
nnoremap <c-p> :ProjectMru --tiebreak=end<cr>
```

I apologize for directly notifying you and won't be doing it again.  Watch the repo if you want to stay up to date on what I think will be infrequent changes from this point.
