### PR TITLE
Fix issue where keybindings weren't passed to sink

### DIFF
--- a/plugin/fzf-filemru.vim
+++ b/plugin/fzf-filemru.vim
@@ -39,7 +39,7 @@ function s:wrap_options(options) abort
   function! wrapped.sink(lines) abort
     let selections = []
     for l in a:lines
-      let l = substitute(l, '^\(\s*\S\+\s*\)', '', '')
+      let l = substitute(l, '^\(\s*\(git\|mru\|\-\)\s\+\)', '', '')
       call add(selections, l)
     endfor
     call s:update_mru(selections)


### PR DESCRIPTION
Hi, this patch is for #5. The original substitute pattern removed the first non-whitespace chunk from the arguments passed to the sink, so instead of

```
ctrl-v
somefile.file
```
we would be passing 
```

somefile.file
```
As a result, no key indicating a split or other command would be passed to the sink for files.