### PR TITLE
Change options to search 2nd token to end of line

### DIFF
--- a/plugin/fzf-filemru.vim
+++ b/plugin/fzf-filemru.vim
@@ -112,7 +112,7 @@ function! s:invoke(git_ls, ignore_submodule, options) abort
 
   call fzf#vim#files('', s:wrap_options({
         \   'source': fzf_source,
-        \   'options': a:options.' --ansi --nth=2',
+        \   'options': a:options.' --ansi --nth=2..',
         \ }))
 endfunction
 


### PR DESCRIPTION
If there are files with space in name, searching them doesn't work because fzf only searches on 2nd token. With this, it will search 2nd token to end of line